### PR TITLE
Add support for passing in alternate templates

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,10 @@
 #   This is the folder to where we need to download the NSCP Installer. Package cannot take a remote file source
 #   Because of Windows, we need to set this to be a top level directory (e.g. c:\\temp) or we would need to
 #   recursively check the file path.
-
+#
+# [*config_template*]
+#   This is the template to use as the config file.
+#
 class nsclient (
   $allowed_hosts           = $nsclient::params::allowed_hosts,
   $service_state           = $nsclient::params::service_state,
@@ -33,12 +36,14 @@ class nsclient (
   $package_source_location = $nsclient::params::package_source_location,
   $package_source          = $nsclient::params::package_source,
   $package_name            = $nsclient::params::package_name,
-  $download_destination    = $nsclient::params::download_destination
+  $download_destination    = $nsclient::params::download_destination,
+  $config_template         = $nsclient::params::config_template
 ) inherits nsclient::params {
 
   validate_string($package_source_location)
   validate_string($package_source)
   validate_string($package_name)
+  validate_string($config_template)
 
   class {'nsclient::install':} ->
   class {'nsclient::service':} ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,4 +10,5 @@ class nsclient::params {
   $package_name            = 'NSClient++ (x64)'
   $package_source          = 'NSCP-0.4.1.101-x64.msi'
   $download_destination    = "c:\\temp"
+  $config_template         = 'nsclient/nsclient.ini.erb'
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,9 +3,10 @@
 # Class to manage the nsclient service
 
 class nsclient::service(
-  $service_state  = $nsclient::service_state,
-  $service_enable = $nsclient::service_enable,
-  $allowed_hosts  = $nsclient::allowed_hosts
+  $service_state   = $nsclient::service_state,
+  $service_enable  = $nsclient::service_enable,
+  $allowed_hosts   = $nsclient::allowed_hosts,
+  $config_template = $nsclient::config_template
 ) {
 
   case downcase($::osfamily) {
@@ -14,7 +15,7 @@ class nsclient::service(
         ensure  => file,
         owner   => 'SYSTEM',
         mode    => '0664',
-        content => template('nsclient/nsclient.ini.erb'),
+        content => template($config_template),
         notify  => Service['nscp']
       }
 


### PR DESCRIPTION
This commit will allow the overriding of the nsclient.ini file with a site specific template.
