### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name":         "puppet-nsclient",
   "version":      "1.3.1",
   "author":       "puppet-community",
-  "license":      "Apache 2.0",
+  "license":      "MIT",
   "summary":      "Module that will install the NSClient on windows servers to be able to interact with Nagios and Icinga. It will also manage the list of hosts that the server can communicate with",
   "source":       "https://github.com/puppet-community/puppet-nsclient",
   "project_page": "https://github.com/puppet-community/puppet-nsclient",


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for quite
some time