### PR TITLE
fix #32 use package install_options hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class nsclient (
   validate_string($config_template)
   validate_string($install_path)
 
-  class {'::nsclient::install':} ->
-  class {'::nsclient::service':}
+  class {'::nsclient::install':}
+  -> class {'::nsclient::service':}
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,13 @@ class nsclient::install {
         ensure          => installed,
         source          => "${nsclient::download_destination}/${nsclient::package_source}",
         provider        => 'windows',
-        install_options => ["INSTALLLOCATION=${nsclient::install_path}", "CONFIGURATION_TYPE=ini://${nsclient::install_path}\\nsclient.ini", '/quiet'],
+        install_options => [
+          '/quiet',
+          {
+            'INSTALLLOCATION'    => $nsclient::install_path,
+            'CONFIGURATION_TYPE' => "ini://${nsclient::install_path}\\nsclient.ini"
+          },
+        ],
         require         => Download_file['NSCP-Installer'],
       }
     }


### PR DESCRIPTION
#32 Appears to be a bug. I have resolved the issue by using a hash in the `install_options` parameter array. The hash is used to pass MSI install properties when using `msiexec.exe`. See: https://docs.puppet.com/puppet/latest/type.html#package-attribute-install_options

- Use hash format to specify msi install opts
- Clean up formatting to make it clear the hash is in the array
- Fix puppet linter issue with ordering operand