### PR TITLE
Add chocolatey as a provider for installing the package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,11 +43,10 @@
 # Password used to authenticate against server
 # default to undef
 #
-<<<<<<< HEAD
 # [*proxy_url*]
 # Specify a proxy url if needed for downloading the package
 # default to undef
-=======
+#
 # [*chocolatey_provider*]
 # Boolean, if true get nsclient from chocolatey. Default to false
 #
@@ -57,7 +56,6 @@
 # [*chocolatey_package_version*]
 # This is the package version from chocolatey repo.
 #
->>>>>>> Add chocolatey as a provider for installing the package
 # === Examples
 #
 # To install a different version:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,19 +75,6 @@
 #   }
 #
 class nsclient (
-<<<<<<< HEAD
-  $allowed_hosts                 = $nsclient::params::allowed_hosts,
-  $service_state                 = $nsclient::params::service_state,
-  $service_enable                = $nsclient::params::service_enable,
-  $package_source_location       = $nsclient::params::package_source_location,
-  $package_source                = $nsclient::params::package_source,
-  $package_name                  = $nsclient::params::package_name,
-  $download_destination          = $nsclient::params::download_destination,
-  $config_template               = $nsclient::params::config_template,
-  $install_path                  = $nsclient::params::install_path,
-  Optional[String[1]] $proxy_url = $nsclient::params::proxy_url,
-  Optional[String[1]] $password  = $nsclient::params::password
-=======
   $allowed_hosts                                  = $nsclient::params::allowed_hosts,
   $service_state                                  = $nsclient::params::service_state,
   $service_enable                                 = $nsclient::params::service_enable,
@@ -98,10 +85,10 @@ class nsclient (
   $config_template                                = $nsclient::params::config_template,
   $install_path                                   = $nsclient::params::install_path,
   Optional[String[1]] $password                   = $nsclient::params::password,
-  Boolean $chocolatey_provider                    =  $nsclient::params::chocolatey_provider,
-  Optional[String[1]] $chocolatey_package_name    =  $nsclient::params::chocolatey_package_name,
+  Optional[String[1]] $proxy_url                  = $nsclient::params::proxy_url,
+  Boolean $chocolatey_provider                    = $nsclient::params::chocolatey_provider,
+  Optional[String[1]] $chocolatey_package_name    = $nsclient::params::chocolatey_package_name,
   Optional[String[1]] $chocolatey_package_version = $nsclient::params::chocolatey_package_version
->>>>>>> Add chocolatey as a provider for installing the package
 ) inherits nsclient::params {
 
   validate_string($package_source_location)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,9 +43,21 @@
 # Password used to authenticate against server
 # default to undef
 #
+<<<<<<< HEAD
 # [*proxy_url*]
 # Specify a proxy url if needed for downloading the package
 # default to undef
+=======
+# [*chocolatey_provider*]
+# Boolean, if true get nsclient from chocolatey. Default to false
+#
+# [*chocolatey_package_name*]
+# This is the package name from chocolatey repo.
+#
+# [*chocolatey_package_version*]
+# This is the package version from chocolatey repo.
+#
+>>>>>>> Add chocolatey as a provider for installing the package
 # === Examples
 #
 # To install a different version:
@@ -63,6 +75,7 @@
 #   }
 #
 class nsclient (
+<<<<<<< HEAD
   $allowed_hosts                 = $nsclient::params::allowed_hosts,
   $service_state                 = $nsclient::params::service_state,
   $service_enable                = $nsclient::params::service_enable,
@@ -74,6 +87,21 @@ class nsclient (
   $install_path                  = $nsclient::params::install_path,
   Optional[String[1]] $proxy_url = $nsclient::params::proxy_url,
   Optional[String[1]] $password  = $nsclient::params::password
+=======
+  $allowed_hosts                                  = $nsclient::params::allowed_hosts,
+  $service_state                                  = $nsclient::params::service_state,
+  $service_enable                                 = $nsclient::params::service_enable,
+  $package_source_location                        = $nsclient::params::package_source_location,
+  $package_source                                 = $nsclient::params::package_source,
+  $package_name                                   = $nsclient::params::package_name,
+  $download_destination                           = $nsclient::params::download_destination,
+  $config_template                                = $nsclient::params::config_template,
+  $install_path                                   = $nsclient::params::install_path,
+  Optional[String[1]] $password                   = $nsclient::params::password,
+  Boolean $chocolatey_provider                    =  $nsclient::params::chocolatey_provider,
+  Optional[String[1]] $chocolatey_package_name    =  $nsclient::params::chocolatey_package_name,
+  Optional[String[1]] $chocolatey_package_version = $nsclient::params::chocolatey_package_version
+>>>>>>> Add chocolatey as a provider for installing the package
 ) inherits nsclient::params {
 
   validate_string($package_source_location)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,18 +33,26 @@ class nsclient::install {
         }
 
 
-      package { $nsclient::package_name:
-        ensure          => installed,
-        source          => "${nsclient::download_destination}/${nsclient::package_source}",
-        provider        => 'windows',
-        install_options => [
-          '/quiet',
-          {
-            'INSTALLLOCATION'    => $nsclient::install_path,
-            'CONFIGURATION_TYPE' => "ini://${nsclient::install_path}\\nsclient.ini"
-          },
-        ],
-        require         => Download_file['NSCP-Installer'],
+      if $nsclient::chocolatey_provider {
+        package { $nsclient::params::chocolatey_package_name:
+          ensure   => $nsclient::chocolatey_package_version,
+          provider => 'chocolatey',
+        }
+      }
+      else {
+        package { $nsclient::package_name:
+          ensure          => installed,
+          source          => "${nsclient::download_destination}/${nsclient::package_source}",
+          provider        => 'windows',
+          install_options => [
+            '/quiet',
+            {
+              'INSTALLLOCATION'    => $nsclient::install_path,
+              'CONFIGURATION_TYPE' => "ini://${nsclient::install_path}\\nsclient.ini"
+            },
+          ],
+          require         => Download_file['NSCP-Installer'],
+        }
       }
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,15 +8,18 @@
 # It sets variables according to platform
 #
 class nsclient::params {
-  $allowed_hosts           = []
-  $service_state           = 'running'
-  $service_enable          = true
-  $package_source_location = 'https://github.com/mickem/nscp/releases/download/0.5.1.28'
-  $package_name            = 'NSClient++ (x64)'
-  $package_source          = 'NSCP-0.5.1.28-x64.msi'
-  $download_destination    = 'c:/temp'
-  $config_template         = 'nsclient/nsclient.ini.erb'
-  $install_path            = 'C:\Program Files\NSClient++'
-  $proxy_url               = undef
-  $password                = undef
+  $allowed_hosts              = []
+  $service_state              = 'running'
+  $service_enable             = true
+  $package_source_location    = 'https://github.com/mickem/nscp/releases/download/0.5.1.28'
+  $package_name               = 'NSClient++ (x64)'
+  $package_source             = 'NSCP-0.5.1.28-x64.msi'
+  $download_destination       = 'c:/temp'
+  $config_template            = 'nsclient/nsclient.ini.erb'
+  $install_path               = 'C:\Program Files\NSClient++'
+  $proxy_url                  = undef
+  $password                   = undef
+  $chocolatey_provider        = false
+  $chocolatey_package_name    = 'nscp'
+  $chocolatey_package_version = '0.5.0.62'
 }


### PR DESCRIPTION
This PR add three variables : 

$chocolatey_provider,
$chocolatey_package_name
$chocolatey_package_version

If the chocolatey_provider is set to true, then nsclient is installed from chocolatey provider.

Let me know what you think about it.
It still need testing.
