### PR TITLE
remove 'mode'  because it is not manage correctly by puppet on windows

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,7 +23,6 @@ class nsclient::service(
       file { "${install_path}\\nsclient.ini":
         ensure  => file,
         owner   => 'SYSTEM',
-        mode    => '0664',
         content => template($config_template),
         notify  => Service['nscp'],
       }


### PR DESCRIPTION
Hi,

setting a 'mode' for nsclient.ini cause trouble because puppet doesn't manage it properly.
So I propose this patch to remove it. File permission will be set by default.