### PR TITLE
download_file should not happen when chocolatey is used

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,11 +19,18 @@ class nsclient::install {
   case downcase($::osfamily) {
     'windows': {
 
-      if ! defined(File[$nsclient::download_destination]) {
-        file { $nsclient::download_destination:
-          ensure => directory,
+      if $nsclient::chocolatey_provider {
+        package { $nsclient::params::chocolatey_package_name:
+          ensure   => $nsclient::chocolatey_package_version,
+          provider => 'chocolatey',
         }
       }
+      else {
+        if ! defined(File[$nsclient::download_destination]) {
+          file { $nsclient::download_destination:
+            ensure => directory,
+          }
+        }
 
         download_file { 'NSCP-Installer':
           url                   => $source,
@@ -32,14 +39,6 @@ class nsclient::install {
           require               => File[$nsclient::download_destination],
         }
 
-
-      if $nsclient::chocolatey_provider {
-        package { $nsclient::params::chocolatey_package_name:
-          ensure   => $nsclient::chocolatey_package_version,
-          provider => 'chocolatey',
-        }
-      }
-      else {
         package { $nsclient::package_name:
           ensure          => installed,
           source          => "${nsclient::download_destination}/${nsclient::package_source}",


### PR DESCRIPTION
Hi,

this is a fix, when using chocolatey, we shoud not execute download_file  because this execute the powershell installation script. 

So I put the code into else statement in order to avoid this situation.

Sorry about this.